### PR TITLE
Add tags page with clean list design

### DIFF
--- a/src/pages/links.js
+++ b/src/pages/links.js
@@ -9,13 +9,20 @@ const LinksPage = () => (
   <Layout>
     <div className="post-content">
       <h1 id="page-title">Links</h1>
+      <h2>Site</h2>
+      <ul>
+        <li>
+          <Link to="/tags">/tags</Link>
+        </li>
+        <li>
+          <Link to="/reviews/tv">/reviews/tv</Link>
+        </li>
+      </ul>
+
       <h2>Movies watch history</h2>
       <a href="https://movies.adityathebe.com/users/adityathebe/dashboard" target="_blank" rel="noreferrer">
         https://movies.adityathebe.com/users/adityathebe/dashboard
       </a>
-
-      <h2>TV Shows watch history</h2>
-      <Link to="/reviews/tv">/reviews/tv</Link>
 
       <h2>Some of my favorite people in Tech</h2>
       <ul>

--- a/src/pages/tags.css
+++ b/src/pages/tags.css
@@ -1,0 +1,109 @@
+.tags-page {
+  padding: 1rem 0;
+}
+
+.tags-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.tags-title {
+  font-size: 2.5em;
+  margin: 0 0 0.5rem 0;
+  background: linear-gradient(135deg, var(--nord-frost-3), var(--nord-frost-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-weight: 900;
+}
+
+.tags-description {
+  color: var(--secondary-text-color);
+  font-size: 1.1em;
+  margin: 0;
+}
+
+.tags-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.tag-item {
+  border-bottom: 1px solid var(--border-color-1);
+}
+
+.tag-item:last-child {
+  border-bottom: none;
+}
+
+.tag-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  position: relative;
+  color: inherit;
+}
+
+.tag-link:visited,
+.tag-link:hover,
+.tag-link:active {
+  color: inherit;
+  text-decoration: none;
+}
+
+.tag-link::before {
+  content: '';
+  position: absolute;
+  left: -0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 0;
+  background: linear-gradient(180deg, var(--nord-frost-3), var(--nord-frost-2));
+  transition: height 0.2s ease;
+  border-radius: 2px;
+}
+
+.tag-link:hover::before {
+  height: 60%;
+}
+
+.tag-link:hover .tag-name {
+  color: var(--nord-frost-3);
+  transform: translateX(0.5rem);
+}
+
+@media screen and (max-width: 450px) {
+  .tags-header {
+    margin-bottom: 2rem;
+  }
+
+  .tags-title {
+    font-size: 1.8em;
+  }
+
+  .tags-description {
+    font-size: 1em;
+  }
+}
+
+.tag-name {
+  font-size: 1em;
+  font-weight: 600;
+  color: var(--primary-text-color);
+  font-family: 'JetBrains Mono', sans-serif;
+  letter-spacing: -0.02em;
+  transition: all 0.2s ease;
+}
+
+.tag-count {
+  font-size: 0.85em;
+  color: var(--secondary-text-color);
+  font-family: 'JetBrains Mono', sans-serif;
+}

--- a/src/pages/tags.js
+++ b/src/pages/tags.js
@@ -1,0 +1,83 @@
+// @ts-check
+import React from 'react';
+import { graphql, useStaticQuery, Link } from 'gatsby';
+
+import Layout from '../components/Layout';
+import { Head as SEOHead } from '../components/SEO';
+import { tagSlug, tagPath, formatTagLabel } from '../utils/tags.js';
+import './tags.css';
+
+const TagsPage = () => {
+  const { allMarkdownRemark } = useStaticQuery(graphql`
+    {
+      allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/content/Posts/" } }) {
+        edges {
+          node {
+            frontmatter {
+              categories
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  // Aggregate tags and count posts
+  const tagCounts = {};
+  allMarkdownRemark.edges.forEach((edge) => {
+    const categories = edge.node.frontmatter.categories || [];
+    categories.forEach((category) => {
+      if (!category) return;
+      const slug = tagSlug(category);
+      if (!slug) return;
+
+      if (!tagCounts[slug]) {
+        tagCounts[slug] = {
+          slug,
+          displayName: formatTagLabel(category),
+          count: 0,
+        };
+      }
+      tagCounts[slug].count += 1;
+    });
+  });
+
+  // Convert to array and sort by count (descending)
+  const tags = Object.values(tagCounts).sort((a, b) => b.count - a.count);
+
+  return (
+    <Layout>
+      <div className="tags-page">
+        <div className="tags-header">
+          <h1 className="tags-title">Explore Topics</h1>
+          <p className="tags-description">
+            {tags.length} {tags.length === 1 ? 'topic' : 'topics'} across all posts
+          </p>
+        </div>
+
+        <ul className="tags-list">
+          {tags.map((tag) => (
+            <li key={tag.slug} className="tag-item">
+              <Link to={tagPath(tag.displayName)} className="tag-link">
+                <span className="tag-name">{tag.displayName}</span>
+                <span className="tag-count">
+                  {tag.count} {tag.count === 1 ? 'post' : 'posts'}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Layout>
+  );
+};
+
+export const Head = () => (
+  <SEOHead
+    title="Topics"
+    description="Explore all topics and tags from Aditya Thebe's blog"
+    keywords={['topics', 'tags', 'categories', 'blog']}
+  />
+);
+
+export default TagsPage;


### PR DESCRIPTION
## Summary
- Created new `/tags` page that displays all blog post tags in a clean, compact list layout
- Tags are sorted by popularity (post count) and include hover animations with Nord gradient accents
- Added tags link to Links page under a new "Site" section for discoverability

## Test plan
- [ ] Visit `/tags` to view all topics
- [ ] Verify tags are sorted by post count (descending)
- [ ] Test hover animations (gradient bar and color transition)
- [ ] Check responsive design on mobile
- [ ] Verify dark mode styling
- [ ] Navigate to tags page from Links page